### PR TITLE
fixed bracket formatting to convention in c#

### DIFF
--- a/hello-world/c#/hello-world.cs
+++ b/hello-world/c#/hello-world.cs
@@ -1,7 +1,9 @@
 using System;
 
-internal static class HelloWorld {
-  private static void Main() {
+internal static class HelloWorld 
+{
+  private static void Main() 
+  {
     Console.WriteLine("Hello World!");
   }
 }


### PR DESCRIPTION
### Why:
The opening curly brackets where not on a newline, which is the standard convention in C#. Might be good to fix for new coders using it as reference.

<!-- If this PR is linked to any issue -->
<!-- please change #ISSUE_NUMBER to the respective issue number -->
<!-- For example, Closes #1 -->
Closes #ISSUE_NUMBER

### What's being changed:

Curly brackets now on a newline
